### PR TITLE
Remove unused CSS class for masuperclass

### DIFF
--- a/test.css
+++ b/test.css
@@ -1,3 +1,0 @@
-.masuperclass {
-  color: red;
-}


### PR DESCRIPTION
This pull request includes a small change to the `test.css` file. The change removes the `.masuperclass` CSS class and its associated styling.